### PR TITLE
128 increase player speed

### DIFF
--- a/Jetpack/Assets/Scenes/Gameplay.unity
+++ b/Jetpack/Assets/Scenes/Gameplay.unity
@@ -9192,7 +9192,7 @@ Rigidbody2D:
   m_Mass: 80
   m_LinearDrag: 1.2
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 1.2
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -9329,8 +9329,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e58980eb46e2af43a87b76d64492aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  velocity: 3
-  acceleration: 0.025
+  velocity: 5
+  acceleration: 0.05
   flyForce: 75
   jumpForce: 3
   maxYValue: 4.5

--- a/Jetpack/Assets/Scripts/Mount/MountAnimationController.cs
+++ b/Jetpack/Assets/Scripts/Mount/MountAnimationController.cs
@@ -31,13 +31,13 @@ namespace Mount
             /*
              * If the player is flying upwards, we want to change the mount animation
              * to flying instead of gliding. Otherwise, the player glides.
-            */
+             */
             this._anim.SetBool(Flying, Input.GetButton("Jump"));
 
             /* If player is not actively flying, then is either gliding or walking on the ground.
              * Walk animation will only play when player is detected touching the ground, so
              * we check if player is touching ground and set the appropriate animation conditions.
-            */
+             */
             this._anim.SetBool(Walking, this._parentController.IsGrounded());
         }
     }

--- a/Jetpack/Assets/Scripts/Player/PlayerMovementController.cs
+++ b/Jetpack/Assets/Scripts/Player/PlayerMovementController.cs
@@ -96,9 +96,9 @@ namespace Player
              * If the player mangages to reach velocity 18, we want to stop accelerating
              * so that the player maintains this speed and does go any faster.
              */
-             if(this.velocity >= 18.0f)
+             if(this.velocity >= 15.0f)
              {
-                this.velocity = 18.0f;
+                this.velocity = 15.0f;
                 this.acceleration = 0.0f;
              }
         }

--- a/Jetpack/Assets/Scripts/Player/PlayerMovementController.cs
+++ b/Jetpack/Assets/Scripts/Player/PlayerMovementController.cs
@@ -8,8 +8,8 @@ namespace Player
     /// </summary>
     public class PlayerMovementController : MonoBehaviour
     {
-        [SerializeField] private float velocity = 3.0f;
-        [SerializeField] private float acceleration = 0.025f;
+        [SerializeField] private float velocity = 5.0f;
+        [SerializeField] private float acceleration = 0.04f;
         [SerializeField] private float flyForce = 75.0f;
         [SerializeField] private float jumpForce = 3.0f;
         [SerializeField] private float maxYValue = 4.5f;
@@ -27,6 +27,7 @@ namespace Player
         private void Update()
         {
             CeilingCheck();
+            VelocityCheck();
 
             // Cancels the rotation of the sprite.
             this.transform.rotation = Quaternion.Euler(0, 0, 0);
@@ -87,6 +88,19 @@ namespace Player
              */
             this._touchingCeiling = (position.y >= this.maxYValue);
             if (this._touchingCeiling) RemoveUpwardsVelocity(position);
+        }
+
+        private void VelocityCheck()
+        {
+            /* 
+             * If the player mangages to reach velocity 18, we want to stop accelerating
+             * so that the player maintains this speed and does go any faster.
+             */
+             if(this.velocity >= 18.0f)
+             {
+                this.velocity = 18.0f;
+                this.acceleration = 0.0f;
+             }
         }
 
         private void RemoveUpwardsVelocity(Vector3 position)


### PR DESCRIPTION
# Pull Request

## Description

Increase player starting velocity from 3 to 5. Increase player acceleration from 0.025 to 0.05. Velocity will cap at 15, where acceleration is then set to 0 to ensure player stays at speed 15.

Fixes #128 

---

## Type of Change

- [ ] Bugfix (Small Non-Code Breaking Issue)
- [ ] Bugfix (Critical Code Breaking Issue)
- [ ] Feature (Something New Added to the Code)
- [x] Improvement (Improving An Existing Section of Code)
- [ ] Artwork/Sprite Update
- [ ] Documentation Update

---

## Changes

- [x] Internal Code
- [ ] Artwork/Sprites
- [ ] Documentation
- [ ] Other: _____

---

## Test Configuration

* Hardware:
  - CPU:
  - GPU:
  - RAM:
  - Architecture: 64-bit
* Unity Version: 2022.2.13f1

---

## Checklist

- [x] This pull request has been linked to the appropriate issue on GitHub. (Use the development section on the right.)
- [x] The code follows the style [guidelines](https://github.com/beanbeanjuice/ecs189L-back-to-the-jungle/blob/master/CONTRIBUTING.md).
- [x] A self-review of the code was performed on GitHub.
- [x] Appropriate comments and [XML comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags) were added in your code.
- [x] Appropriate changes have been made to the documentation.
- [x] Appropriate changes have been made to the `README.md` file.
- [x] No warnings are produced when the code is run.
- [x] The pull request is properly merging into the correct branch.
- [x] All existing local code has been pushed to the GitHub repository.
- [x] Another person has reviewed and approved the code.
- [x] I will remember to close the issue this pull request solves if this pull request does not automatically close the issue.
